### PR TITLE
Prewarm GPS on watch launch

### DIFF
--- a/BigMetric Watch App/App/RootBigMetricView.swift
+++ b/BigMetric Watch App/App/RootBigMetricView.swift
@@ -73,13 +73,14 @@ struct RootBigMetricView: View {
 			.tabItem { Image(systemName: "doc.text.magnifyingglass") }
 			.tag(9)
 	  }
-	  .onAppear {
-		 unifiedWorkoutManager.onEndAndShowSummary = {
-			self.selectedTab = 4
-		 }
-		 unifiedWorkoutManager.requestHKAuth()
-		 selectedTab = 2
-	  }
+          .onAppear {
+                 unifiedWorkoutManager.onEndAndShowSummary = {
+                        self.selectedTab = 4
+                 }
+                 unifiedWorkoutManager.requestHKAuth()
+                 unifiedWorkoutManager.prewarmGPS()
+                 selectedTab = 2
+          }
 	  .tabViewStyle(PageTabViewStyle())
    }
 }

--- a/BigMetric Watch App/Classes/UnifiedWorkoutManager.swift
+++ b/BigMetric Watch App/Classes/UnifiedWorkoutManager.swift
@@ -882,11 +882,17 @@ class UnifiedWorkoutManager: NSObject,
    }
    
    func forceLocationRefresh() {
-	  LMDelegate.stopUpdatingLocation()
-	  // Wait briefly before restarting
-	  DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-		 self?.LMDelegate.startUpdatingLocation()
-	  }
+          LMDelegate.stopUpdatingLocation()
+          // Wait briefly before restarting
+          DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                 self?.LMDelegate.startUpdatingLocation()
+          }
+   }
+
+   /// Starts location updates to warm up GPS without beginning a workout.
+   func prewarmGPS() {
+          LMDelegate.delegate = self
+          LMDelegate.startUpdatingLocation()
    }
    
    // MARK: - Automatic Workout Detection Methods


### PR DESCRIPTION
## Summary
- add `prewarmGPS` method to `UnifiedWorkoutManager`
- start GPS updates in `RootBigMetricView` when the interface appears

## Testing
- `swiftc -parse "BigMetric Watch App/Classes/UnifiedWorkoutManager.swift"`
- `swiftc -parse "BigMetric Watch App/App/RootBigMetricView.swift"`
